### PR TITLE
Update test vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## DID Method Onion Specification
 
-This specification describes a [DID Method](https://www.w3.org/TR/did-core/) related to [TOR Hidden Services](https://2019.www.torproject.org/docs/onion-services)
+This specification describes a [DID Method](https://www.w3.org/TR/did-core/) related to [Tor Hidden Services](https://2019.www.torproject.org/docs/onion-services)
 
 We encourage contributions meeting the [Contribution
 Guidelines](CONTRIBUTING.md). While we prefer the creation of issues

--- a/index.html
+++ b/index.html
@@ -105,12 +105,12 @@ Example
   "@context": ["https://www.w3.org/ns/did/v1"],
   "id": "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid",
   "verificationMethod": [{
-    "id": "#z6MkhXq6jnd4hRnsgzpBBntqQSL452UzrhjmxSfdkrmHagL8",
+    "id": "#g7r2t9G8dBBnG7yZkD8sly3ImDlrntB25s2pGuaD97E",
     "type": "JsonWebKey2020",
     "controller": "did:onion:fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid",
     "publicKeyJwk": {
       "crv": "Ed25519",
-      "x": "Lb7CMu_9Cqf5bB_Ke9Yzyep85dt3BSvlFlCnJt2aHjk",
+      "x": "LIUp9Jdi2R17QcZnbPFZOYyV5oyotNHU2J5dQUdTUa4",
       "kty": "OKP"
     }
   }]

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 DIDs that target a distributed ledger face significant practical challenges in
 bootstrapping enough meaningful trusted data around identities to incentivize
 mass adoption. We propose using a new DID method that allows them to 
-bootstrap trust using a TOR Hidden Service's existing reputation.
+bootstrap trust using a Tor Hidden Service's existing reputation.
       </p>
     </section>
     <section id="sotd">
@@ -129,8 +129,8 @@ DID Onion Method
 Target system
         </h2>
         <p>
-The target system of the Onion DID method is the TOR Hidden Service that the identifier
-described by the DID resolves to when queried through TOR.
+The target system of the Onion DID method is the Tor Hidden Service that the identifier
+described by the DID resolves to when queried through Tor.
         </p>
       </section>
 
@@ -152,13 +152,13 @@ lowercase. The remainder of the DID, after the prefix, is specified below.
 Method-specific identifier
         </h2>
         <p>
-The method specific identifier is a TOR Hidden Service identifier 
+The method specific identifier is a Tor Hidden Service identifier 
 with an optional path to the DID document.
 The formal rules describing valid onion address syntax are described in
 [[rfc7686]].
         </p>
         <p>
-The method specific identifier MUST match the TOR Hidden Service, 
+The method specific identifier MUST match the Tor Hidden Service, 
 and it MUST NOT include IP addresses or port numbers. Directories
 and subdirectories MAY optionally be included, delimited by colons rather
 than slashes.
@@ -191,7 +191,7 @@ Creating a DID is done by:
           </p>
           <ol>
             <li>
-generating and operating a TOR Hidden Service that serves a filesystem directory.
+generating and operating a Tor Hidden Service that serves a filesystem directory.
             </li>
             <li>
 storing the location of a hosting service.
@@ -252,7 +252,7 @@ Append <code>/did.json</code> to complete the URL.
             </li>
             <li>
 Perform an HTTP <code>GET</code> request to the URL using an agent that can
-successfully negotiate a secure HTTP connection to a TOR Hidden Service, which enforces the security
+successfully negotiate a secure HTTP connection to a Tor Hidden Service, which enforces the security
 requirements as described in <a href="#security-and-privacy-considerations"></a>.
             </li>
           </ol>
@@ -299,7 +299,7 @@ Security and Privacy Considerations
 
         <section>
           <h3>
-TOR Considerations
+Tor Considerations
           </h3>
 
           <p class="issue" >

--- a/index.html
+++ b/index.html
@@ -116,6 +116,16 @@ Example
   }]
 }
         </pre>
+
+        <p class="note">
+          The <code>id</code> of the verification method SHOULD be the JWK
+          thumbprint calculated from the <code>publicKeyJwk</code> property
+          value according to [[RFC7638]] or
+
+          <a href="https://w3c-ccg.github.io/did-method-key/#format">
+          <code>did:key</code> Multicodec identifier</a> for the <code>publicKeyBase58</code> property.
+        </p>
+
       </section>
     </section>
 


### PR DESCRIPTION
## Abstract

This PR updates the test vector to reflect the fact that there is a single `ed25519` keypair. The ed25519 pubkey is part of the onion address: `onion_address = base32(PUBKEY | CHECKSUM | VERSION) + ".onion"` 

Also, I'm getting different results when calculating `id`. Orie's library gives `id` `z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp` for a `seed of 32 zeros`:

```bash
gorazd@gorazd-MS-7C37:~/Desktop/testing/did-onion.js/packages/did-onion-cli$ node generate.js 
<Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>
{ ed25519: 
   { id: '#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp',
     type: 'JsonWebKey2020',
     controller: 'did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp',
     publicKeyJwk: 
      { crv: 'Ed25519',
        x: 'O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik',
        kty: 'OKP' },
```
My library gives id `9ZP03Nu8GrXPAUkbKNxHOKBzxPX83SShgFkRNK-f2lw` generated with this code snippet
```bash
    let str_json = json!({
      "crv": "Ed25519",
      "kty": "OKP",
      "x": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik"
    });

    let mut str_str = str_json.to_string();
    str_str.retain(|c| !c.is_whitespace());
    println!("{}", str_str); // {"crv":"Ed25519","kty":"OKP","x":"O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik"}

    use sha2::Sha256;
    let mut hasher = Sha256::new();
    hasher.update(&str_str);
    let id_ed255 = hasher.finalize();
    let id_ed255 = base64url::encode_nopad(&id_ed255);
    println!("{}", id_ed255);
```
The algo was tested correctly against https://w3c-ccg.github.io/lds-jws2020/#example-4

## Other

Our site `http://fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion` was updated to show the example that Orie has come up with in `https://github.com/OR13/did-onion.js`

These changes are now also reflected in `https://github.com/BlockchainCommons/torgap-demo` where one can set up the hidden service on a linode with their own minisign secret key. It is now based on [warp server](https://github.com/seanmonstar/warp)

[torgap-sig](https://github.com/BlockchainCommons/torgap-sig-cli-rust) now allows generating a simple DID document and Tor v3 authentication keys (for client authorization)



