### PR TITLE
Link to implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,13 +369,14 @@ of fscst5exmlmr262byztwz4kzhggjlzumvc2ndvgytzoucr2tkgxf7mid.onion.
       </section>
     </section>
 
-    <section class="appendix informative">
+    <section class="appendix informative" id="implementations">
       <h1>
-Reference implementations
+Reference Implementations
       </h1>
-      <p class="issue" >
-        There are no known implementations.
-      </p>
+      <ul>
+        <li><a href="https://github.com/OR13/did-onion.js">did-onion.js</a></li>
+        <li><a href="https://github.com/spruceid/ssi/tree/main/did-onion">did-onion in Rust</a></li>
+      </ul>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Address #3, linking to did-onion.js by @OR13, and did-onion by @spruceid.

The Rust implementation was also submitted to the [DID Test Suite](https://w3c.github.io/did-test-suite/), using the DID and DID document from this specification as a test vector:
https://github.com/w3c/did-test-suite/pull/185